### PR TITLE
Refactor: Remove unused dependencies and update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,20 +17,17 @@ authors = [
 dependencies = [
   "numpy",
   "tqdm",
-  "spacy",
-  "google-genai",
   "requests",
-  "httpx",
   "Pillow",
   "openai",
   "anthropic",
   "opencv-python",
   "python-dotenv",
   "datasets",
-  "faiss-cpu",
+  "faiss",
   "torch",
-  "mkdocs",
-  "transformers"
+  "transformers",
+  "vertexai"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+anthropic==0.53.0
+datasets==3.6.0
+faiss==1.5.3
+numpy==2.3.0
+openai==1.85.0
+Pillow==11.2.1
+protobuf==6.31.1
+python-dotenv==1.1.0
+Requests==2.32.4
+torch==2.7.1
+tqdm==4.67.1
+transformers==4.52.4
+vertexai==1.71.1


### PR DESCRIPTION
This commit removes unused packages from the project's dependencies listed in `pyproject.toml`. I used a tool to identify actively imported packages.

Changes:
- Removed: spacy, google-genai, httpx, mkdocs
- Added: vertexai (identified as used)
- Updated: faiss-cpu to faiss (to align with the tool's output)

I confirmed `opencv-python` as a necessary dependency despite the tool not being able to resolve its import `cv2` directly.